### PR TITLE
If connection fails, set result to 0 instead of failing entirely

### DIFF
--- a/fastdotcom/__init__.py
+++ b/fastdotcom/__init__.py
@@ -14,7 +14,12 @@ def gethtmlresult(url,result,index):
   '''
   get the stuff from url in chuncks of size CHUNK, and keep writing the number of bytes retrieved into result[index]
   '''
-  req = urllib.request.urlopen(url)
+  try:
+    req = urllib.request.urlopen(url)
+  except urllib.error.URLError:
+    result[index] = 0
+    return
+
   CHUNK = 100 * 1024
   i=1
   while True:


### PR DESCRIPTION
Previously if the code encountered a broken internet connection, it would crash and burn. Since I am using this in an application to monitor my internet bandwidth over time, this was unacceptable. I made an edit to treat a broken connection as a bandwidth of '0', instead of crashing. I'm not sure whether this is wanted for the base project but figured I'd PR it anyways.