### PR TITLE
Error handling and state added in case of no internet connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ print(result)
 
 When you run the example above, you might see output similar to:
 ```bash
-{'download_speed': 120.68, 'upload_speed': 25.93, 'unloaded_ping': 19.35, 'loaded_ping': 48.64}
+{'download_speed': 120.68, 'upload_speed': 25.93, 'unloaded_ping': 19.35, 'loaded_ping': 48.64, 'success': 1}
 ```
 
 - **Download Speed:** Measured download speed in Mbps (displayed with two decimal places).
 - **Upload Speed:** Measured upload speed in Mbps (displayed with two decimal places).
 - **Unloaded Ping:** Average ping (latency) when the network is idle.
 - **Loaded Ping:** Average ping (latency) during a download test.
+- **Success:** An indication if the speed test was performed successfully (zero if no internet connection was available).
 
 ## Requirements
 - Python 3.8 or newer

--- a/fastdotcom/__init__.py
+++ b/fastdotcom/__init__.py
@@ -681,13 +681,13 @@ def fast_com(
 ):
     token = get_fast_token(verbose=verbose)
     if not token:
-        return (
-    "download_speed": 0,
-    "upload_speed": 0,
-    "unloaded_ping": 0,
-    "loaded_ping": 0,
-    "success": 0,
-        )
+        return {
+        "download_speed": 0,
+        "upload_speed": 0,
+        "unloaded_ping": 0,
+        "loaded_ping": 0,
+        "success": 0,
+        }
 
     avg_ping_unloaded, ping_unloaded_vals = fast_com_ping_unloaded(
         token=token, verbose=verbose, count=ping_count

--- a/fastdotcom/__init__.py
+++ b/fastdotcom/__init__.py
@@ -682,11 +682,11 @@ def fast_com(
     token = get_fast_token(verbose=verbose)
     if not token:
         return (
-            "Failed to get token. All test values will be 0.\n"
-            "Download Speed: 0.00 Mbps\n"
-            "Upload Speed: 0.00 Mbps\n"
-            "Unloaded Ping: 0 ms\n"
-            "Loaded Ping: 0 ms"
+    "download_speed": 0,
+    "upload_speed": 0,
+    "unloaded_ping": 0,
+    "loaded_ping": 0,
+    "success": 0,
         )
 
     avg_ping_unloaded, ping_unloaded_vals = fast_com_ping_unloaded(
@@ -704,6 +704,7 @@ def fast_com(
     "upload_speed": upload_speed_dynamic,
     "unloaded_ping": avg_ping_unloaded,
     "loaded_ping": avg_ping_loaded,
+    "success": 1,
     }
     return result
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ SOFTWARE.
 """
 
 setup(name='fastdotcom',
-      version='0.0.4',
+      version='0.0.5',
       description='Python API for testing internet speed on Fast.com',
       url='https://github.com/nkgilley/fast.com',
       author='Nolan Gilley',


### PR DESCRIPTION
I just found that I need a consistent output for the Homeassistant integration, meaning all zeros if the test fails due to no internet.

I added this functionality with this version. Increased to version 0.0.5. I hope I can finish my PR to Homeassistant without further changes to this repo.