### PR TITLE
adjustment of requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,6 @@ setup(name='fastdotcom',
       url='https://github.com/nkgilley/fast.com',
       author='Nolan Gilley',
       license='MIT',
-      install_requires=['requests>=2.0','icmplib>=3.0.4'],
+      install_requires=['requests>=2.0','icmplib>=3.0.0'],
       packages=['fastdotcom'],
       zip_safe=True)

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ SOFTWARE.
 """
 
 setup(name='fastdotcom',
-      version='0.0.5',
+      version='0.0.6',
       description='Python API for testing internet speed on Fast.com',
       url='https://github.com/nkgilley/fast.com',
       author='Nolan Gilley',


### PR DESCRIPTION
home assistant needs icmplib to be <=3.0.0 therefore I changed it. Would be great if you could merge that one. Sorry for the inconvenience.